### PR TITLE
Make /bin/sh command in so_nice_we_ran_it_twice test POSIX-compliant

### DIFF
--- a/tests/spawn.rs
+++ b/tests/spawn.rs
@@ -11,7 +11,7 @@ use std::io::Result;
 #[test]
 fn so_nice_we_ran_it_twice() -> Result<()> {
     let mut command = SealedCommand::new(&mut File::open("/bin/sh")?)?;
-    command.arg("--version");
+    command.arg("-c").arg("/bin/true");
     for _ in 0..2 {
         assert!(command.output()?.status.success());
     }


### PR DESCRIPTION
Fixes #2. Test confirmed working on Ubuntu 18.04 (arm-unknown-linux-gnueabihf) and Fedora 30 (x86_64-unknown-linux-gnu).