### PR TITLE
Support running interpreter scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0] - 2020-06-23
+### Changed
+- No longer set `MFD_CLOEXEC` if `#!` is detected at the beginning of a program
+
+## [0.1.1] - 2020-03-15
+### Changed
+- Allow builds on Android platforms
+
+## [0.1.0] - 2019-11-15
+### Added
+- Everything!
+
+[Unreleased]: https://github.com/iliana/pentacle/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/iliana/pentacle/compare/v0.1.1...v0.2.0
+[0.1.1]: https://github.com/iliana/pentacle/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/iliana/pentacle/releases/tag/v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "pentacle"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["iliana destroyer of worlds <iliana@buttslol.net>"]
 edition = "2018"
-exclude = [".gitignore"]
+exclude = ["bors.toml", ".github", ".gitignore"]
 description = "Executes programs as sealed anonymous files on Linux"
 repository = "https://github.com/iliana/pentacle"
 readme = "README.md"

--- a/tests/spawn.rs
+++ b/tests/spawn.rs
@@ -17,3 +17,13 @@ fn so_nice_we_ran_it_twice() -> Result<()> {
     }
     Ok(())
 }
+
+// Test that we can execute a script with a shebang.
+#[test]
+fn shebang() {
+    let mut command = SealedCommand::new(&mut &b"#!/bin/sh\necho 'it works'\n"[..]).unwrap();
+    let output = command.output().unwrap();
+    eprintln!("{}", String::from_utf8_lossy(&output.stderr));
+    assert!(output.status.success());
+    assert_eq!(output.stdout, b"it works\n");
+}


### PR DESCRIPTION
If the program starts with `#!` (a shebang or hash-bang), the kernel will (almost always; depends if `BINFMT_SCRIPT` is enabled) determine which interpreter to exec and pass the script along as the first argument. In this case, the argument will be `/proc/self/fd/{}`, which gets closed if MFD_CLOEXEC is set.

We now check for `#!` and only set MFD_CLOEXEC if it's not there.

cc @tjkirch, @webern